### PR TITLE
Make help message clearer

### DIFF
--- a/lib/resty/commands/method_command.rb
+++ b/lib/resty/commands/method_command.rb
@@ -37,9 +37,9 @@ Pry::Commands.create_command /(get|put|post|delete|head|options|patch)/i,
 
   def process
     if path_missing?
-      "Missing path. Type 'method-command -h' for more info."
+      "Missing path. Type '#{http_method} -h' for more info, or 'help'."
     elsif data_invalid?
-      "Invalid data. Type 'method-command -h' for more info."
+      "Invalid data. Type '#{http_method} -h' for more info, or 'help'."
     else
       params = { method: http_method, path: path, data: data }
       request = Resty::Request.new(global_options, params)


### PR DESCRIPTION
I struggled a bit when first using ruby-resty, trying to figure out how to get the help message to show up. The original message is a little bit unclear.

I've just changed the wording so that it will show:

``` ruby
resty> GET
Missing path. Type 'GET -h' for more info, or 'help'.
```

But definitely open to other suggestions if you can think of something better.
